### PR TITLE
Fix XSS "Online movies" 

### DIFF
--- a/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItem.php
+++ b/src/Backend/Modules/MediaLibrary/Domain/MediaItem/MediaItem.php
@@ -4,6 +4,8 @@ namespace Backend\Modules\MediaLibrary\Domain\MediaItem;
 
 use Backend\Modules\MediaLibrary\Component\StorageProvider\LiipImagineBundleStorageProviderInterface;
 use Backend\Modules\MediaLibrary\Component\StorageProvider\StorageProviderInterface;
+use Backend\Modules\MediaLibrary\Domain\MediaGroupMediaItem\MediaGroupMediaItem;
+use DateTime;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -42,7 +44,8 @@ class MediaItem implements JsonSerializable
      * @ORM\JoinColumn(
      *      name="mediaFolderId",
      *      referencedColumnName="id",
-     *      onDelete="cascade"
+     *      onDelete="cascade",
+     *      nullable=false
      * )
      */
     protected $folder;
@@ -69,14 +72,14 @@ class MediaItem implements JsonSerializable
     protected $type;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(type="string", nullable=true)
      */
     protected $mime;
 
     /**
-     * @var string
+     * @var string|null
      *
      * @ORM\Column(type="string", nullable=true)
      */
@@ -97,49 +100,49 @@ class MediaItem implements JsonSerializable
     protected $title;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(type="integer", nullable=true)
      */
     protected $size;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(type="integer", nullable=true)
      */
     protected $width;
 
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(type="integer", nullable=true)
      */
     protected $height;
 
     /**
-     * @var AspectRatio
+     * @var AspectRatio|null
      *
      * @ORM\Column(type="media_item_aspect_ratio", nullable=true)
      */
     protected $aspectRatio;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      *
      * @ORM\Column(type="datetime")
      */
     protected $createdOn;
 
     /**
-     * @var \DateTime
+     * @var DateTime
      *
      * @ORM\Column(type="datetime")
      */
     protected $editedOn;
 
     /**
-     * @var ArrayCollection
+     * @var Collection<MediaGroupMediaItem>
      *
      * @ORM\OneToMany(
      *     targetEntity="Backend\Modules\MediaLibrary\Domain\MediaGroupMediaItem\MediaGroupMediaItem",
@@ -164,8 +167,8 @@ class MediaItem implements JsonSerializable
         $this->storageType = $storageType;
         $this->url = $url;
         $this->title = $title;
-        $this->createdOn = new \DateTime();
-        $this->editedOn = new \DateTime();
+        $this->createdOn = new DateTime();
+        $this->editedOn = new DateTime();
         $this->groups = new ArrayCollection();
     }
 
@@ -243,7 +246,7 @@ class MediaItem implements JsonSerializable
         $mediaItem->title = $mediaItemDataTransferObject->title;
         $mediaItem->folder = $mediaItemDataTransferObject->folder;
         $mediaItem->userId = $mediaItemDataTransferObject->userId;
-        $mediaItem->url = $mediaItemDataTransferObject->url;
+        $mediaItem->url = htmlspecialchars($mediaItemDataTransferObject->url);
 
         return $mediaItem;
     }
@@ -408,12 +411,12 @@ class MediaItem implements JsonSerializable
         return $this->height;
     }
 
-    public function getCreatedOn(): \DateTime
+    public function getCreatedOn(): DateTime
     {
         return $this->createdOn;
     }
 
-    public function getEditedOn(): \DateTime
+    public function getEditedOn(): DateTime
     {
         return $this->editedOn;
     }
@@ -501,7 +504,7 @@ class MediaItem implements JsonSerializable
      */
     public function onPrePersist()
     {
-        $this->createdOn = $this->editedOn = new \DateTime();
+        $this->createdOn = $this->editedOn = new DateTime();
 
         $this->refreshAspectRatio();
     }
@@ -511,7 +514,7 @@ class MediaItem implements JsonSerializable
      */
     public function onPreUpdate()
     {
-        $this->editedOn = new \DateTime();
+        $this->editedOn = new DateTime();
 
         $this->refreshAspectRatio();
     }


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/11-other-forkcms/forkcms/

### ⚙️ Description *

The `forkcms` is vulnerable to XSS through `Online movies` id edition.

### 💻 Technical Description *

The `Online movies` id is being sanitized only in the upload process and not in the edition process.

### 🐛 Proof of Concept (PoC) *

1. With an authenticated user, access `http://localhost/private/en/media_library/media_item_index`.
2. Click on `New media`.
3. Select `Online movies (Youtube, Vimeo, ...)` and click on `Next`.
4. Select any `Source`, write anything in the `Movie id` and `Movie title` fields and click on `Add movie`.
5. Click on `Back to overview`.
6. Select the `Movies` tab and click on `Edit` over the movie added before.
7. In the `Movie ID` field, write `<img src onerror=alert()>` and click on `Save`. An alert will pop up.

[PoC video](https://i.imgur.com/H0hySQq.mp4).

### 🔥 Proof of Fix (PoF) *

The PoC steps do not work anymore. The characters `<` and `>` are being sanitized.

Fix XSS "Online movies" 